### PR TITLE
fix: メッセージ時刻表示の不整合を修正

### DIFF
--- a/src/backend/schemas.py
+++ b/src/backend/schemas.py
@@ -1,6 +1,6 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_serializer
 
 
 def to_camel(string: str) -> str:
@@ -20,6 +20,13 @@ class MessageBase(BaseModel):
     timestamp: datetime
     is_own_message: bool
 
+    @field_serializer("timestamp")
+    def serialize_timestamp(self, dt: datetime) -> str:
+        """タイムスタンプをUTC ISO形式で出力"""
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.isoformat()
+
 
 class MessageCreate(MessageBase):
     pass
@@ -31,6 +38,13 @@ class MessageResponse(MessageBase):
     )
 
     created_at: datetime
+
+    @field_serializer("created_at")
+    def serialize_created_at(self, dt: datetime) -> str:
+        """created_atをUTC ISO形式で出力"""
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.isoformat()
 
 
 class ChannelBase(BaseModel):
@@ -47,6 +61,13 @@ class ChannelResponse(ChannelBase):
     )
 
     created_at: datetime
+
+    @field_serializer("created_at")
+    def serialize_created_at(self, dt: datetime) -> str:
+        """created_atをUTC ISO形式で出力"""
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.isoformat()
 
 
 class MessagesListResponse(BaseModel):


### PR DESCRIPTION
## Summary
- バックエンドでタイムスタンプをUTC ISO形式で統一出力するよう修正
- メッセージ時刻表示の不整合問題（00:49 vs 09:50）を解決
- リロード時の時刻リセット問題を修正

## 修正内容
- Pydanticスキーマに`@field_serializer`を追加してタイムスタンプ統一処理を実装
- `MessageBase`, `MessageResponse`, `ChannelResponse`のタイムスタンプ出力を標準化
- タイムゾーン情報の明示的設定により一貫した時刻表示を実現

## Test plan
- [x] e2eテストで報告された時刻表示バグの修正確認
- [x] APIレスポンスでUTC ISO形式でのタイムスタンプ出力確認
- [x] フロントエンドでの時刻変換テスト実行
- [x] リロード後の時刻表示一貫性確認
- [x] XSS脆弱性の調査（React標準機能により既に対策済み確認）

🤖 Generated with [Claude Code](https://claude.ai/code)