### PR TITLE
メッセージ入力をShift+Enter送信に変更

### DIFF
--- a/src/frontend/src/components/MessageInput.tsx
+++ b/src/frontend/src/components/MessageInput.tsx
@@ -1,4 +1,4 @@
-import { Group, TextInput, ActionIcon } from '@mantine/core';
+import { Group, Textarea, ActionIcon } from '@mantine/core';
 import { IconSend } from '@tabler/icons-react';
 import { useState, useRef } from 'react';
 
@@ -18,7 +18,7 @@ export function MessageInput({ onSendMessage }: MessageInputProps) {
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey && !isComposingRef.current) {
+    if (e.key === 'Enter' && e.shiftKey && !isComposingRef.current) {
       e.preventDefault();
       handleSend();
     }
@@ -34,8 +34,8 @@ export function MessageInput({ onSendMessage }: MessageInputProps) {
 
   return (
     <Group gap='sm' style={{ padding: '1.5rem 1.5rem 3rem 1.5rem' }}>
-      <TextInput
-        placeholder='メッセージを入力...'
+      <Textarea
+        placeholder='メッセージを入力... (Shift+Enterで送信)'
         value={message}
         onChange={(e) => setMessage(e.currentTarget.value)}
         onKeyDown={handleKeyPress}
@@ -45,6 +45,9 @@ export function MessageInput({ onSendMessage }: MessageInputProps) {
         style={{ flex: 1 }}
         size='md'
         radius='xl'
+        minRows={1}
+        maxRows={5}
+        autosize
       />
       <ActionIcon
         onClick={handleSend}


### PR DESCRIPTION
## Summary
- メッセージ入力の操作性を改善
- TextInputからTextareaに変更して複数行メッセージをサポート
- Enter: 改行、Shift+Enter: 送信に変更

## Test plan
- [ ] メッセージ入力でEnterキーを押すと改行される
- [ ] Shift+Enterでメッセージが送信される
- [ ] プレースホルダーでShift+Enterでの送信方法が案内される
- [ ] autosizeとmaxRows設定により適切にテキストエリアがリサイズされる
- [ ] ESLintとビルドが正常に通る

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - メッセージ入力欄が複数行対応になり、自動で1～5行まで拡張されるようになりました。
- **改善**
  - メッセージ送信方法が「Shift+Enter」キーに変更され、プレースホルダーもそれに合わせて更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->